### PR TITLE
Configurable logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,16 @@ Barchart.configure do |config|
 end
 ```
 
+You can optionally override the logger with:
+
+``ruby
+# Use the Rails logger:
+Barchart.logger = Rails.logger
+
+# If you don't want to output any logs (e.g. in tests):
+Barchart.logger = Logger.new(nil)
+```
+
 # Usage
 
 ## Barchart::Quote

--- a/lib/barchart.rb
+++ b/lib/barchart.rb
@@ -6,6 +6,7 @@ require 'recursive-open-struct'
 
 require 'barchart/version'
 require 'barchart/configuration'
+require 'barchart/logger'
 require 'barchart/request'
 require 'barchart/resources/resource'
 require 'barchart/resources/quote'

--- a/lib/barchart/logger.rb
+++ b/lib/barchart/logger.rb
@@ -1,0 +1,11 @@
+module Barchart
+  class << self
+    attr_writer :logger
+
+    def logger
+      @logger ||= Logger.new($stdout).tap do |log|
+        log.progname = self.name
+      end
+    end
+  end
+end

--- a/lib/barchart/request.rb
+++ b/lib/barchart/request.rb
@@ -17,7 +17,7 @@ module Barchart
     end
 
     def execute
-      p url
+      Barchart.logger.info "#{method}: #{url}"
       response = RestClient::Request.new({
         url: url,
         method: method,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ Barchart.configure do |config|
   config.api_base_url = "http://api_base_url"
   config.api_key = "secret"
 end
+Barchart.logger = Logger.new(nil)
 
 RSpec.configure do |config|
   if ENV['CI']


### PR DESCRIPTION
Example configuration:

``` ruby
Barchart.logger = Rails.logger
```

Example output:

```
I, [2016-01-27T01:05:21.381230 #47342]  INFO -- Barchart: get: http://barcharts.com/getQuote.json?symbols=GOOGL,CBO.TO&fields=bid,ask&apikey=secret
```
